### PR TITLE
Migrates CI build from Travis to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: build and test
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6']
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Create a virtual environment
+        run: python3 -m venv ./venv && . venv/bin/activate
+      - run: pip install -r requirements.txt
+      - run: pip install -e .
+      - run: python ionhashtest/ion_hash_test_driver.py --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-python: "3.5"
-install:
-  - pip install -r requirements.txt
-  - pip install -e .
-script:
-  - python ionhashtest/ion_hash_test_driver.py --help
-


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Migrates CI build from Travis to Github Actions

Also updates the CI build from python 3.5 (no longer supported, so build fails) to the same set of python versions used in the CI build for `ion-hash-python`.

Successful run [here](https://github.com/popematt/ion-hash-test-driver/actions/runs/1313074331).


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
